### PR TITLE
fix: Improve type usability by refining AtomTree and Node type definitions

### DIFF
--- a/src/atomTree.ts
+++ b/src/atomTree.ts
@@ -5,7 +5,10 @@ type Node<AtomType extends Atom<unknown> = Atom<unknown>> = {
   atom?: AtomType
 }
 
-type AtomTree<Path extends unknown[], AtomType extends Atom<unknown>> = {
+type AtomTree<
+  Path extends readonly unknown[],
+  AtomType extends Atom<unknown>,
+> = {
   (path: Path): AtomType
   remove(path?: Path, removeSubTree?: boolean): void
   getSubTree(path?: Path): Node<AtomType>
@@ -20,11 +23,11 @@ type AtomTree<Path extends unknown[], AtomType extends Atom<unknown>> = {
  * @returns A function for creating and managing hierarchical atoms (with additional methods).
  */
 export function atomTree<
-  Path extends unknown[],
+  Path extends readonly unknown[],
   AtomType extends Atom<unknown>,
 >(initializePathAtom: (path: Path) => AtomType): AtomTree<Path, AtomType> {
   const root: Node<AtomType> = {}
-  const defaultPath = [] as unknown[] as Path
+  const defaultPath = [] as readonly unknown[] as Path
 
   /**
    * Creates or retrieves an atom at the specified path in the hierarchy.


### PR DESCRIPTION
Make the "Path" type (an array of something) read-only.

A readonly array is a better default argument or generic type because it can contain both an immutable and a mutable array.

## Example of current issue:
```ts
const myTree1 = atomTree((path: string[]) => atom((get) => {
  // ...
}));

// Typescript error expected below:
// ---
// Argument of type '(path: readonly string[]) => Atom<void>' is not assignable to parameter of type '(path: unknown[]) => Atom<void>'.
//   Types of parameters 'path' and 'path' are incompatible.
//     Type 'unknown[]' is not assignable to type 'readonly string[]'.
//       Type 'unknown' is not assignable to type 'string'
const myTree2 = atomTree((path: readonly string[]) => atom((get) => {
  // ...
}));
```

## Expected behaviour:

```ts
type MyNode = {
  readonly id: string;
  readonly name: string;
  readonly path: readonly string[];
}
const allNodesAtom = atom<ReadonlyMap<MyNode["id"], MyNode>>(new Map());

const myTree = atomTree((path: MyNode["path"]) => atom((get) => {
  const allNodes = get(allNodesAtom);
  // ...
}));
```


---

- BC: **no**
- We can provide the type of path in many different ways. E.g. `atomTree((path: MyNode["path"]) => … )`. The `MyNode` can be readonly type.
- Sometime is important be strict with immutable types. Current solution is not support these solution without workaround.
- Adding `readonly` is not BC. All currect scenarious will work same. Because mutable version of array can be assign to readonly one.